### PR TITLE
Change the order of dependencies install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ You'll first need to install [ESLint](http://eslint.org):
 $ npm install eslint --save-dev
 ```
 
-Next, install `eslint-plugin-prettier`:
-
-```
-$ npm install eslint-plugin-prettier --save-dev
-```
-
-Finally, install `prettier`:
+Next, install `prettier`:
 
 ```
 $ npm install prettier --save-dev
+```
+
+Finally, install `eslint-plugin-prettier`:
+
+```
+$ npm install eslint-plugin-prettier --save-dev
 ```
 
 **Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-prettier` globally.


### PR DESCRIPTION
Hey!

I noticed while following the readme, that the install order is wrong.

Installing `eslint-plugin-prettier` before `prettier` yield this error:
```
├── eslint-plugin-prettier@2.0.1
└── UNMET PEER DEPENDENCY prettier@>= 0.11.0

npm WARN eslint-plugin-prettier@2.0.1 requires a peer of prettier@>= 0.11.0 but none was installed.
```
So I swapped the steps in the readme. Cheers!