### PR TITLE
README - Updating prettier options in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Then configure the `prettier` rule under the `rules` section:
 }
 ```
 
-You can also pass `prettier` configuration as an option:
+You can also pass [`prettier` configuration](https://github.com/prettier/prettier#api) as an option:
 
 ```json
 {
     "rules": {
-        "prettier/prettier": ["error", {"trailingComma": true, "singleQuote": true}]
+        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}]
     }
 }
 ```


### PR DESCRIPTION
Updating the example section to use the correct option, there's no `true` anymore,

The available options are: `none`, `es5` and `all`,

Also, adding a link to the API section, https://github.com/prettier/prettier#api, where you can find more options and the correct values