### PR TITLE
New: allow using forks of `prettier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you'd like to use a fork of `prettier`, pass its name as an additional option
 ```json
 {
     "rules": {
-        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, "prettier-with-tabs"]
+        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, "prettier-miscellaneous"]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ You can also pass [`prettier` configuration](https://github.com/prettier/prettie
 }
 ```
 
+If you'd like to use a fork of `prettier`, pass its name as an additional option:
+
+```json
+{
+    "rules": {
+        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, 'prettier-with-tabs']
+    }
+}
+```
+
 The rule will report an error if your code does not match `prettier` style. The rule is autofixable -- if you run `eslint` with the `--fix` flag, your code will be formatted according to `prettier` style.
 
 ---

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you'd like to use a fork of `prettier`, pass its name as an additional option
 ```json
 {
     "rules": {
-        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, 'prettier-with-tabs']
+        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, "prettier-with-tabs"]
     }
 }
 ```

--- a/lib/rules/prettier.js
+++ b/lib/rules/prettier.js
@@ -12,7 +12,7 @@ const prettier = require('prettier');
 // Rule Definition
 // ------------------------------------------------------------------------------
 module.exports = {
-  meta: { fixable: 'code', schema: [{ type: 'object' }] },
+  meta: { fixable: 'code', schema: [{ type: 'object' }, { type: 'string' }] },
   create(context) {
     const sourceCode = context.getSourceCode();
 
@@ -35,9 +35,12 @@ module.exports = {
 
     return {
       Program() {
+        const customPrettier = context.options.length > 1
+          ? require(context.options[1])
+          : prettier;
         // This isn't really very performant (prettier needs to reparse the text).
         // However, I don't think it's possible to run `prettier` on an ESTree AST.
-        const desiredText = prettier.format(
+        const desiredText = customPrettier.format(
           sourceCode.text,
           context.options[0]
         );

--- a/lib/rules/prettier.js
+++ b/lib/rules/prettier.js
@@ -7,6 +7,7 @@
 
 const util = require('util');
 const prettier = require('prettier');
+const requireindex = require('requireindex');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -35,9 +36,13 @@ module.exports = {
 
     return {
       Program() {
-        const customPrettier = context.options.length > 1
-          ? require(context.options[1])
-          : prettier;
+        let customPrettier = prettier;
+        if (context.options.length > 1) {
+          const prettierPath = 'node_modules/' + context.options[1];
+          customPrettier = requireindex(process.cwd(), [prettierPath])[
+            prettierPath
+          ];
+        }
         // This isn't really very performant (prettier needs to reparse the text).
         // However, I don't think it's possible to run `prettier` on an ESTree AST.
         const desiredText = customPrettier.format(


### PR DESCRIPTION
This makes it possible for projects to specify the name of a `prettier`
fork to be used instead of the original `prettier`. The fork name is
passed as an additional option after the `prettier` configuration. For
example:

```json
{
    "rules": {
        "prettier/prettier": ["error", {"trailingComma": "es5", "singleQuote": true}, "prettier-with-tabs"]
    }
}
```